### PR TITLE
Add support for webln payments

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -206,15 +206,29 @@ const renderAmountDialog = async (npub, relays) => {
       amount,
       comment,
     });
-    const invoiceDialog = renderInvoiceDialog({
-      dialogHeader: await getDialogHeader(),
-      invoice,
-    });
-    const openWalletButton = invoiceDialog.querySelector(".cta-button");
+    
+    // function to show the invoice QR code if webln is not available or the user cancels webln
+    const showInvoiceInDialog = () => {
+      const invoiceDialog = renderInvoiceDialog({
+        dialogHeader: await getDialogHeader(),
+        invoice,
+      });
+      const openWalletButton = invoiceDialog.querySelector(".cta-button");
 
-    amountDialog.close();
-    invoiceDialog.showModal();
-    openWalletButton.focus();
+      amountDialog.close();
+      invoiceDialog.showModal();
+      openWalletButton.focus();
+    };
+    
+    if (window.webln) { 
+      try { 
+        await window.webln.enable();
+        const response = await window.webln.sendPayment(invoice);
+      } catch(e) {
+        showInvoiceInDialog();
+    } else {
+      showInvoiceInDialog();
+    }
   });
 
   return amountDialog;


### PR DESCRIPTION
Similar to requesting the zap signatures from the user the payment can be called with window.webln 

> WebLN is a set of specifications for Lightning apps and client providers to facilitate communication between web apps and users' Lightning nodes in a secure way. It provides a programmatic, permissioned interface for letting applications ask users to send payments, generate invoices to receive payments, and much more.

https://www.webln.guide/

This is a quick example on how it could look like. (edited on GitHub, so handle with care, but I hope it is a start)