### PR TITLE
add: background-color: white to class=nostr-zap-dialog

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -449,6 +449,7 @@ export const injectCSS = () => {
         text-align: center;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+        background-color: white;
       }
       .nostr-zap-dialog[open],
       .nostr-zap-dialog form {


### PR DESCRIPTION
This pull request includes a small change to the `src/view.js` file. The change adds a background color to the CSS styles injected by the `injectCSS` function.

* [`src/view.js`](diffhunk://#diff-6816f949b9ec9feb0eef92eb76ea23f7c6b872d544ae1872cd3a79d4f4e8a34bR452): Added a `background-color` property with the value `white` to the CSS styles injected by the `injectCSS` function.

Background color changes when **prefers-color-scheme: dark**, making text difficult to read.
prefers-color-scheme: dark is set when the OS or browser is in dark mode.
![スクリーンショット 2024-12-13 210440](https://github.com/user-attachments/assets/ea75480f-3e90-450f-bb47-2b240923a0e1)