### PR TITLE
fix: QR Code Readability in Dark Mode by Adding Quiet Zone

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -130,7 +130,7 @@ const renderInvoiceDialog = ({
     },
   });
 
-  new QRCode(qrCodeEl, { text: invoice });
+  new QRCode(qrCodeEl, { text: invoice, quietZone: 10 });
 
   qrCodeEl.addEventListener("click", function () {
     navigator.clipboard.writeText(invoice);


### PR DESCRIPTION
This modification adds a quiet zone to the generated QR codes, ensuring proper readability.

Previously, QR codes were generated without a quiet zone, which caused readability issues in dark mode environments (e.g., the Dark Reader browser extension). By adding this quiet zone, the QR codes are now reliably readable in such cases.

![image](https://github.com/user-attachments/assets/6511bdb3-c4ae-4418-84dd-c9f32e4ad461)
*Before: QR Code without Quiet Zone, causing readability issues in Dark Mode environments.*

The following images illustrate the improvement. The first shows the issue without a quiet zone, and the second demonstrates the fix with a quiet zone applied.


![image](https://github.com/user-attachments/assets/e32c0544-8bb9-4425-a6fa-f7ea5fa79eb6)
*After: QR Code with Quiet Zone, resolving readability issues in Dark Mode environments.*

