### PR TITLE
Fix CDN import crash when script loads before body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,17 @@
 import { injectCSS, init, initTargets, initTarget } from "./view";
 
-injectCSS();
-initTargets();
+// Wait for <body> before mounting the shadow host. Scripts loaded from a CDN
+// in <head> (common with unpkg/jsdelivr) otherwise crash with:
+// Cannot read properties of null (reading 'appendChild')
+const boot = () => {
+  injectCSS();
+  initTargets();
+};
 
-window.nostrZap = {init, initTarget, initTargets};
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}
+
+window.nostrZap = { init, initTarget, initTargets };

--- a/src/view.js
+++ b/src/view.js
@@ -102,6 +102,7 @@ const renderDialog = (htmlStrTemplate) => {
     }
   });
 
+  injectCSS();
   shadow.appendChild(dialog);
 
   return dialog;
@@ -542,6 +543,10 @@ export const initTargets = (selector) => {
 };
 
 export const injectCSS = () => {
+  if (shadow) {
+    return;
+  }
+
   const styleElement = document.createElement("style");
 
   styleElement.innerHTML = `


### PR DESCRIPTION
## Summary
- Fixes [#26](https://github.com/SamSamskies/nostr-zap/issues/26): CDN scripts (unpkg/jsdelivr) loaded in `<head>` crashed since v1.0.0 with `Cannot read properties of null (reading 'appendChild')` because Shadow DOM setup appended to `document.body` immediately at import time.
- Defer `injectCSS()` / `initTargets()` until `DOMContentLoaded` when the document is still loading, and make `injectCSS` idempotent so dialogs can lazily ensure the shadow root exists.

## Test plan
- [ ] Load `dist/main.js` from a `<script>` in `<head>` (no `defer`/`async`) and confirm the console has no `appendChild` TypeError
- [ ] Confirm `[data-npub]` buttons still auto-bind after page load
- [ ] Confirm existing end-of-`<body>` script usage (README / example) still works
- [ ] Confirm clicking a zap button opens the amount dialog as before


Made with [Cursor](https://cursor.com)